### PR TITLE
Abs of unsigned values bug fixed.

### DIFF
--- a/WhatsNew
+++ b/WhatsNew
@@ -1,5 +1,10 @@
 This is a list of important changes in SGE's version history.
 
+010517:
+- Abs of unsigned values bug fixed.
+- Include SDL path fixed.
+- using namespace std removed.
+
 030809:
 -Better Makefiles (autodetects SDL, Freetype & SDL_Image).
 -Better library numbering (thanks Sam!).

--- a/sge_blib.cpp
+++ b/sge_blib.cpp
@@ -19,10 +19,11 @@
 *  Written with some help from Johan E. Thelin.
 */
 
-#include "SDL.h"
 #include "sge_surface.h"
 #include "sge_primitives.h"
 #include "sge_blib.h"
+
+#include <SDL2/SDL.h>
 
 #define SWAP(x,y,temp) temp=x;x=y;y=temp
 

--- a/sge_blib.h
+++ b/sge_blib.h
@@ -18,9 +18,9 @@
 #ifndef sge_blib_H
 #define sge_blib_H
 
-#include "SDL.h"
 #include "sge_internal.h"
 
+#include <SDL2/SDL.h>
 
 #ifdef _SGE_C
 extern "C" {

--- a/sge_bm_text.cpp
+++ b/sge_bm_text.cpp
@@ -21,21 +21,20 @@
 *  Thanks to Karl Bartel for the SFont format!
 */
 
-#include "SDL.h"
-#include <stdarg.h>
-#include <string.h>
-#include <math.h>
-#include <new>
 #include "sge_surface.h"
 #include "sge_bm_text.h"
 #include "sge_tt_text.h"
 #include "sge_textpp.h"
 
-#ifdef _SGE_HAVE_IMG
-#include <SDL_image.h>
-#endif
+#include <SDL2/SDL.h>
+#include <cmath>
+#include <cstdarg>
+#include <cstring>
+#include <new>
 
-using namespace std;
+#ifdef _SGE_HAVE_IMG
+#include <SDL2/SDL_image.h>
+#endif
 
 /* Globals used for sge_Update/sge_Lock (defined in sge_surface) */
 extern Uint8 _sge_update;
@@ -48,7 +47,7 @@ sge_bmpFont* sge_BF_CreateFont(SDL_Surface *surface, Uint8 flags)
 {
 	sge_bmpFont	*font;
 
-	font = new(nothrow) sge_bmpFont; if(font==NULL){SDL_SetError("SGE - Out of memory");return NULL;}
+	font = new(std::nothrow) sge_bmpFont; if(font==NULL){SDL_SetError("SGE - Out of memory");return NULL;}
 	
 	if(!(flags&SGE_BFNOCONVERT) && !(flags&SGE_BFSFONT)){    /* Get a converted copy */
 		SDL_assert(0 && "sge_BF_CreateFont");
@@ -120,7 +119,7 @@ sge_bmpFont* sge_BF_CreateFont(SDL_Surface *surface, Uint8 flags)
 		Sint16 x=0;
 		int i=0;
 		
-		font->CharPos = new(nothrow) Sint16[256];
+		font->CharPos = new(std::nothrow) Sint16[256];
 		if(!font->CharPos){SDL_SetError("SGE - Out of memory");sge_BF_CloseFont(font);return NULL;}
 		
 		Uint32 color = sge_GetPixel(fnt,0,0);  //get data color

--- a/sge_bm_text.h
+++ b/sge_bm_text.h
@@ -18,8 +18,9 @@
 #ifndef sge_bm_text_H
 #define sge_bm_text_H
 
-#include "SDL.h"
 #include "sge_internal.h"
+
+#include <SDL2/SDL.h>
 
 /* BF open flags */
 #define SGE_BFTRANSP SGE_FLAG1

--- a/sge_collision.cpp
+++ b/sge_collision.cpp
@@ -15,15 +15,14 @@
  *  version 2 of the License, or (at your option) any later version. *
  *********************************************************************/
 
-#include "SDL.h"
-#include <stdio.h>
-#include <string.h>
-#include <new>
 #include "sge_collision.h"
 #include "sge_surface.h"
 #include "sge_shape.h"
 
-using namespace std;
+#include <SDL2/SDL.h>
+#include <cstdio>
+#include <cstring>
+#include <new>
 
 Uint8 sge_mask[8]={SGE_FLAG1,SGE_FLAG2,SGE_FLAG3,SGE_FLAG4,SGE_FLAG5,SGE_FLAG6,SGE_FLAG7,SGE_FLAG8};
 SDL_Rect _ua;
@@ -43,11 +42,11 @@ sge_cdata *sge_make_cmap(SDL_Surface *img)
 	Uint32 key;
 	int i;
 	
-	cdata=new(nothrow) sge_cdata;
+	cdata=new(std::nothrow) sge_cdata;
 	if(!cdata){SDL_SetError("SGE - Out of memory");return NULL;}
 	cdata->w=img->w; cdata->h=img->h;
 	offs=(img->w*img->h)/8;
-	cdata->map=new(nothrow) Uint8[offs+2];
+	cdata->map=new(std::nothrow) Uint8[offs+2];
 	if(!cdata->map){SDL_SetError("SGE - Out of memory");return NULL;}
 	memset(cdata->map,0x00,offs+2);
 	

--- a/sge_collision.h
+++ b/sge_collision.h
@@ -18,8 +18,9 @@
 #ifndef sge_collision_H
 #define sge_collision_H
 
-#include "SDL.h"
 #include "sge_internal.h"
+
+#include <SDL2/SDL.h>
 
 /* The collision struct */
 typedef struct

--- a/sge_misc.cpp
+++ b/sge_misc.cpp
@@ -15,13 +15,13 @@
  *  version 2 of the License, or (at your option) any later version. *
  *********************************************************************/
 
-#include "SDL.h"
-#include <stdlib.h>
-#include <stdio.h>
-#include <time.h>
-#include <math.h>
 #include "sge_misc.h"
 
+#include <SDL2/SDL.h>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
 
 Uint32 delay_res=10;
 

--- a/sge_misc.h
+++ b/sge_misc.h
@@ -18,8 +18,9 @@
 #ifndef sge_misc_H
 #define sge_misc_H
 
-#include "SDL.h"
 #include "sge_internal.h"
+
+#include <SDL2/SDL.h>
 
 #ifdef _SGE_C
 extern "C" {

--- a/sge_primitives.cpp
+++ b/sge_primitives.cpp
@@ -20,14 +20,14 @@
 *  John Garrison's PowerPak	
 */
 
-#include "SDL.h"
-#include <math.h>
-#include <string.h>
-#include <stdarg.h>
-#include <stdlib.h>
 #include "sge_primitives.h"
 #include "sge_surface.h"
 
+#include <SDL2/SDL.h>
+#include <cmath>
+#include <cstdarg>
+#include <cstdlib>
+#include <cstring>
 
 /* Globals used for sge_Update/sge_Lock (defined in sge_surface) */
 extern Uint8 _sge_update;

--- a/sge_primitives.h
+++ b/sge_primitives.h
@@ -18,9 +18,9 @@
 #ifndef sge_primitives_H
 #define sge_primitives_H
 
-#include "SDL.h"
 #include "sge_internal.h"
 
+#include <SDL2/SDL.h>
 
 #ifdef _SGE_C
 extern "C" {

--- a/sge_rotation.cpp
+++ b/sge_rotation.cpp
@@ -15,12 +15,13 @@
  *  version 2 of the License, or (at your option) any later version. *
  *********************************************************************/
 
-#include "SDL.h"
-#include <stdio.h>
-#include <math.h>
 #include "sge_rotation.h"
 #include "sge_surface.h"
 #include "sge_blib.h"
+
+#include <SDL2/SDL.h>
+#include <cmath>
+#include <cstdio>
 
 #define SWAP(x,y,temp) temp=x;x=y;y=temp
 

--- a/sge_rotation.h
+++ b/sge_rotation.h
@@ -18,8 +18,9 @@
 #ifndef sge_rotation_H
 #define sge_rotation_H
 
-#include "SDL.h"
 #include "sge_internal.h"
+
+#include <SDL2/SDL.h>
 
 /* Transformation flags */
 #define SGE_TAA SGE_FLAG1

--- a/sge_shape.cpp
+++ b/sge_shape.cpp
@@ -27,6 +27,11 @@
 
 using namespace std;
 
+template <typename T>
+T absDiff(T a, T b)
+{
+    return (a > b) ? (a - b) : (b - a);
+}
 
 sge_screen *the_screen=NULL;  //The pointer to the active screen class (or NULL)
 
@@ -218,14 +223,14 @@ int sge_surface::get_warp(SDL_Rect rec, SDL_Rect &r1, SDL_Rect &r2, SDL_Rect &r3
 		if(rec.x<border.x){
 			r1.w = border.x - rec.x;
 			r1.x = border.x + border.w - r1.w;
-			r2.w = abs(rec.w - r1.w);           //SDL_Rect w/h is unsigned
+			r2.w = absDiff(rec.w, r1.w);           //SDL_Rect w/h is unsigned
 			r2.x = border.x;
 			rects=2; 
 		}else if(rec.x+rec.w > border.x + border.w){
 			r1.x = rec.x;
 			r1.w = border.x + border.w - rec.x;
 			r2.x = border.x;
-			r2.w = abs(rec.w - r1.w);
+			r2.w = absDiff(rec.w, r1.w);
 			rects=2;
 		}
 		
@@ -236,13 +241,13 @@ int sge_surface::get_warp(SDL_Rect rec, SDL_Rect &r1, SDL_Rect &r2, SDL_Rect &r3
 			if(rects==0){
 				r1.h = border.y - rec.y;
 				r1.y = border.y + border.h - r1.h;
-				r2.h = abs(rec.h - r1.h);
+				r2.h = absDiff(rec.h, r1.h);
 				r2.y = border.y;
 				rects=2;
 			}else{
 				r2.h = r1.h= border.y - rec.y;
 				r2.y = r1.y= border.y + border.h - r1.h;
-				r4.h = r3.h= abs(rec.h - r1.h);
+				r4.h = r3.h= absDiff(rec.h, r1.h);
 				r4.y = r3.y= border.y;
 				rects=4;
 			}
@@ -251,13 +256,13 @@ int sge_surface::get_warp(SDL_Rect rec, SDL_Rect &r1, SDL_Rect &r2, SDL_Rect &r3
 				r1.y = rec.y;
 				r1.h = border.y + border.h - rec.y;
 				r2.y = border.y;
-				r2.h = abs(rec.h - r1.h);
+				r2.h = absDiff(rec.h, r1.h);
 				rects=2;
 			}else{
 				r2.y = r1.y = rec.y;
 				r2.h = r1.h = border.y + border.h - rec.y;
 				r4.y = r3.y = border.y;
-				r4.h = r3.h = abs(rec.h - r1.h);
+				r4.h = r3.h = absDiff(rec.h, r1.h);
 				rects=4;
 			}
 		}	

--- a/sge_shape.cpp
+++ b/sge_shape.cpp
@@ -15,17 +15,16 @@
  *  version 2 of the License, or (at your option) any later version. *
  *********************************************************************/
 
-#include "SDL.h"
-#include <stdio.h>
-#include <math.h>
 #include "sge_surface.h"
 #include "sge_primitives.h"
 #include "sge_shape.h"
 #include "sge_misc.h"
 
-#ifndef _SGE_NO_CLASSES
+#include <SDL2/SDL.h>
+#include <cstdio>
+#include <cmath>
 
-using namespace std;
+#ifndef _SGE_NO_CLASSES
 
 template <typename T>
 T absDiff(T a, T b)

--- a/sge_shape.h
+++ b/sge_shape.h
@@ -18,8 +18,9 @@
 #ifndef sge_shape_H
 #define sge_shape_H
 
-#include "SDL.h"
 #include "sge_internal.h"
+
+#include <SDL2/SDL.h>
 
 #ifndef _SGE_NO_CLASSES
 

--- a/sge_surface.cpp
+++ b/sge_surface.cpp
@@ -20,12 +20,12 @@
 *  John Garrison's PowerPak	
 */
 
-#include "SDL.h"
-#include <math.h>
-#include <string.h>
-#include <stdarg.h>
 #include "sge_surface.h"
 
+#include <SDL2/SDL.h>
+#include <cmath>
+#include <cstdarg>
+#include <cstring>
 
 /* Globals used for sge_Update/sge_Lock */
 Uint8 _sge_update=1;

--- a/sge_surface.h
+++ b/sge_surface.h
@@ -18,9 +18,9 @@
 #ifndef sge_surface_H
 #define sge_surface_H
 
-#include "SDL.h"
 #include "sge_internal.h"
 
+#include <SDL2/SDL.h>
 
 /*
 *  Obsolete function names

--- a/sge_textpp.cpp
+++ b/sge_textpp.cpp
@@ -18,17 +18,14 @@
  *  version 2 of the License, or (at your option) any later version. *
  *********************************************************************/
 
-#include "SDL.h"
-#include <stdlib.h>
-#include <stdarg.h>
 #include "sge_surface.h"
 #include "sge_textpp.h"
 
+#include <SDL2/SDL.h>
+#include <cstdarg>
+#include <cstdlib>
+
 #ifndef _SGE_NO_CLASSES
-
-
-using namespace std;
-
 
 //==================================================================================
 // sge_TextEditor

--- a/sge_textpp.h
+++ b/sge_textpp.h
@@ -21,16 +21,17 @@
 #ifndef sge_textpp_H
 #define sge_textpp_H
 
-#include "SDL.h"
 #include "sge_internal.h"
 
 #ifndef _SGE_NO_CLASSES
 
-#include <string>
-#include <stdio.h>
 #include "sge_tt_text.h"
 #include "sge_bm_text.h"
 #include "sge_shape.h"
+
+#include <SDL2/SDL.h>
+#include <string>
+#include <cstdio>
 
 //==================================================================================
 // Edits text from SDL_Event

--- a/sge_tt_text.cpp
+++ b/sge_tt_text.cpp
@@ -24,16 +24,17 @@
 */	
 
 
-#include "SDL.h"
-#include "SDL_endian.h"
-#include <stdlib.h>
-#include <string.h>
-#include <stdarg.h>
-#include <math.h>
 #include "sge_surface.h"
 #include "sge_primitives.h"
 #include "sge_tt_text.h"
 #include "sge_textpp.h"
+
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_endian.h>
+#include <cmath>
+#include <cstdarg>
+#include <cstdlib>
+#include <cstring>
 
 #ifndef _SGE_NOTTF
 #include <freetype/freetype.h>

--- a/sge_tt_text.h
+++ b/sge_tt_text.h
@@ -21,8 +21,9 @@
 #ifndef sge_tt_text_H
 #define sge_tt_text_H
 
-#include "SDL.h"
 #include "sge_internal.h"
+
+#include <SDL2/SDL.h>
 
 /* Text input flags */
 #define SGE_IBG SGE_FLAG1


### PR DESCRIPTION
Width and Height of SDL_Rect is unsigned, so `abs(unsigned - unsigned)` isn't good idea.
Below simple replacement of std::abs() for unsigned values.

```
template <typename T>
T absDiff(T a, T b)
{
    return (a > b) ? (a - b) : (b - a);
}
```